### PR TITLE
Add HasCallStack constraints to all functions

### DIFF
--- a/primitive-checked.cabal
+++ b/primitive-checked.cabal
@@ -37,7 +37,7 @@ library
   hs-source-dirs:
       src
   build-depends:
-      base >=4.7 && <5
+      base >=4.9 && <5
     , primitive == 0.6.3.*
   exposed-modules:
     Data.Primitive

--- a/src/Data/Primitive/UnliftedArray.hs
+++ b/src/Data/Primitive/UnliftedArray.hs
@@ -29,39 +29,40 @@ import Control.Monad.Primitive (PrimMonad,PrimState)
 import Control.Exception (throw, ArrayException(..))
 import "primitive" Data.Primitive.UnliftedArray (UnliftedArray,MutableUnliftedArray,PrimUnlifted)
 import qualified "primitive" Data.Primitive.UnliftedArray as A
+import GHC.Stack
 
-check :: String -> Bool -> a -> a
+check :: HasCallStack => String -> Bool -> a -> a
 check _      True  x = x
-check errMsg False _ = throw (IndexOutOfBounds $ "Data.Primitive.UnliftedArray.Checked." ++ errMsg)
+check errMsg False _ = throw (IndexOutOfBounds $ "Data.Primitive.UnliftedArray.Checked." ++ errMsg ++ "\n" ++ prettyCallStack callStack)
 
-newUnliftedArray :: (PrimMonad m, PrimUnlifted a) => Int -> a -> m (MutableUnliftedArray (PrimState m) a)
+newUnliftedArray :: (HasCallStack, PrimMonad m, PrimUnlifted a) => Int -> a -> m (MutableUnliftedArray (PrimState m) a)
 newUnliftedArray n x = check "newUnliftedArray: negative size" (n>=0) (A.newUnliftedArray n x)
 
-unsafeNewUnliftedArray :: PrimMonad m => Int -> m (MutableUnliftedArray (PrimState m) a)
+unsafeNewUnliftedArray :: (HasCallStack, PrimMonad m) => Int -> m (MutableUnliftedArray (PrimState m) a)
 unsafeNewUnliftedArray n = check "unsafeNewUnliftedArray: negative size" (n>=0) (A.unsafeNewUnliftedArray n)
 
-readUnliftedArray :: (PrimMonad m, PrimUnlifted a) => MutableUnliftedArray (PrimState m) a -> Int -> m a
+readUnliftedArray :: (HasCallStack, PrimMonad m, PrimUnlifted a) => MutableUnliftedArray (PrimState m) a -> Int -> m a
 readUnliftedArray marr i = do
   let siz = A.sizeofMutableUnliftedArray marr
   check "readUnliftedArray: index of out bounds" (i>=0 && i<siz) (A.readUnliftedArray marr i)
 
-writeUnliftedArray :: (PrimMonad m, PrimUnlifted a) => MutableUnliftedArray (PrimState m) a -> Int -> a -> m ()
+writeUnliftedArray :: (HasCallStack, PrimMonad m, PrimUnlifted a) => MutableUnliftedArray (PrimState m) a -> Int -> a -> m ()
 writeUnliftedArray marr i x = do
   let siz = A.sizeofMutableUnliftedArray marr
   check "writeUnliftedArray: index of out bounds" (i>=0 && i<siz) (A.writeUnliftedArray marr i x)
 
-indexUnliftedArray :: PrimUnlifted a => UnliftedArray a -> Int -> a
+indexUnliftedArray :: (HasCallStack, PrimUnlifted a) => UnliftedArray a -> Int -> a
 indexUnliftedArray arr i = check "indexUnliftedArray: index of out bounds"
   (i>=0 && i<A.sizeofUnliftedArray arr)
   (A.indexUnliftedArray arr i)
 
-indexUnliftedArrayM :: (Monad m, PrimUnlifted a) => UnliftedArray a -> Int -> m a
+indexUnliftedArrayM :: (HasCallStack, Monad m, PrimUnlifted a) => UnliftedArray a -> Int -> m a
 indexUnliftedArrayM arr i = check "indexUnliftedArrayM: index of out bounds"
     (i>=0 && i<A.sizeofUnliftedArray arr)
     (A.indexUnliftedArrayM arr i)
 
 freezeUnliftedArray
-  :: PrimMonad m
+  :: (HasCallStack, PrimMonad m)
   => MutableUnliftedArray (PrimState m) a -- ^ source
   -> Int -- ^ offset
   -> Int -- ^ length
@@ -73,7 +74,7 @@ freezeUnliftedArray marr s l = do
     (A.freezeUnliftedArray marr s l)
 
 thawUnliftedArray
-  :: PrimMonad m
+  :: (HasCallStack, PrimMonad m)
   => UnliftedArray a -- ^ source
   -> Int -- ^ offset
   -> Int -- ^ length
@@ -82,7 +83,7 @@ thawUnliftedArray arr s l = check "thawArr: index range of out bounds"
     (s>=0 && l>=0 && (s+l)<=A.sizeofUnliftedArray arr)
     (A.thawUnliftedArray arr s l)
 
-copyUnliftedArray :: PrimMonad m
+copyUnliftedArray :: (HasCallStack, PrimMonad m)
   => MutableUnliftedArray (PrimState m) a -- ^ destination array
   -> Int -- ^ offset into destination array
   -> UnliftedArray a -- ^ source array
@@ -96,7 +97,7 @@ copyUnliftedArray marr s1 arr s2 l = do
     (A.copyUnliftedArray marr s1 arr s2 l)
 
 
-copyMutableUnliftedArray :: PrimMonad m
+copyMutableUnliftedArray :: (HasCallStack, PrimMonad m)
   => MutableUnliftedArray (PrimState m) a    -- ^ destination array
   -> Int                             -- ^ offset into destination array
   -> MutableUnliftedArray (PrimState m) a    -- ^ source array
@@ -111,8 +112,8 @@ copyMutableUnliftedArray marr1 s1 marr2 s2 l = do
     (A.copyMutableUnliftedArray marr1 s1 marr2 s2 l)
 
 
-cloneUnliftedArray ::
-     UnliftedArray a -- ^ source array
+cloneUnliftedArray :: HasCallStack
+  => UnliftedArray a -- ^ source array
   -> Int -- ^ offset into destination array
   -> Int -- ^ number of elements to copy
   -> UnliftedArray a
@@ -120,7 +121,7 @@ cloneUnliftedArray arr s l = check "cloneUnliftedArray: index range of out bound
     (s>=0 && l>=0 && (s+l)<=A.sizeofUnliftedArray arr)
     (A.cloneUnliftedArray arr s l)
 
-cloneMutableUnliftedArray :: PrimMonad m
+cloneMutableUnliftedArray :: (HasCallStack, PrimMonad m)
   => MutableUnliftedArray (PrimState m) a -- ^ source array
   -> Int -- ^ offset into destination array
   -> Int -- ^ number of elements to copy


### PR DESCRIPTION
Given that this package is exclusively aimed at debugging, getting a callstack on failures is quite helpful in my experience. One thing to consider is backwards compatibility. In this PR I’ve just bumped the lower bound on base to 4.9 which supports the API that is being used here and still covers the 3 release support window that a lot of the Haskell ecosystem sticks to. If you prefer to keep backwards compatibility, we could use a combination of the [call-stack](https://hackage.haskell.org/package/call-stack) package and our own CPP (for `prettyCallStack`) but for a package aimed exclusively at debugging, I’m not sure that’s worth the effort.