### PR TITLE
Update to 0.7.2.0

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,0 @@
-import Distribution.Simple
-main = defaultMain

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,0 @@
-module Main where
-
-import Lib
-
-main :: IO ()
-main = someFunc

--- a/primitive-checked.cabal
+++ b/primitive-checked.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name: primitive-checked
-version: 0.7.0.0
+version: 0.7.2.0
 synopsis: primitive functions with bounds-checking
 homepage: https://github.com/andrewthad/primitive-checked#readme
 bug-reports: https://github.com/andrewthad/primitive-checked/issues
@@ -24,10 +24,10 @@ description:
   facilities.
   .
   The versioning for this library matches the version of primitive
-  that is targeted. The first three digits of the version match the
-  version of `primitive`. The fourth digit is used for bug fixes.
+  that is targeted. The first three numbers of the version match the
+  version of `primitive`. The fourth number is used for bug fixes.
   This packages deviates slightly from the PVP in that functions
-  can be added to the API with only a bump to the fourth digit.
+  can be added to the API with only a bump to the fourth number.
 
 extra-source-files:
   README.md
@@ -40,8 +40,8 @@ library
   hs-source-dirs:
       src
   build-depends:
-      base >=4.9.1.0 && <5
-    , primitive == 0.7.0.*
+      base >= 4.9.1.0 && < 5
+    , primitive == 0.7.2.*
   exposed-modules:
     Data.Primitive
     Data.Primitive.Array
@@ -57,4 +57,3 @@ library
     , Data.Primitive.Types
   default-language: Haskell2010
   ghc-options: -Wall
-

--- a/src/Data/Primitive/Array.hs
+++ b/src/Data/Primitive/Array.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE PackageImports #-}
+{-# LANGUAGE UnboxedTuples #-}
 
 module Data.Primitive.Array
   ( Array(..)
@@ -9,6 +11,7 @@ module Data.Primitive.Array
   , writeArray
   , indexArray
   , indexArrayM
+  , indexArray##
   , freezeArray
   , thawArray
   , unsafeFreezeArray
@@ -20,46 +23,65 @@ module Data.Primitive.Array
   , cloneMutableArray
   , A.sizeofArray
   , A.sizeofMutableArray
+  , A.fromListN
+  , A.fromList
+  , A.arrayFromListN
+  , A.arrayFromList
+  , A.mapArray'
+  , A.traverseArrayP
   ) where
 
 import Control.Monad.Primitive (PrimMonad,PrimState)
-import Control.Exception (throw, ArrayException(..))
+import Control.Exception (throw, ArrayException(..), Exception, toException)
 import qualified Data.List as L
 import "primitive" Data.Primitive.Array (Array,MutableArray)
 import qualified "primitive" Data.Primitive.Array as A
+import GHC.Exts (raise#)
 import GHC.Stack
 
 check :: HasCallStack => String -> Bool -> a -> a
 check _      True  x = x
-check errMsg False _ = throw (IndexOutOfBounds $ "Data.Primitive.Array.Checked." ++ errMsg ++ "\n" ++ prettyCallStack callStack)
+check errMsg False _ = throw (IndexOutOfBounds $ "Data.Primitive.Array." ++ errMsg ++ "\n" ++ prettyCallStack callStack)
+
+checkUnary :: HasCallStack => String -> Bool -> (# a #) -> (# a #)
+checkUnary _      True  x = x
+checkUnary errMsg False _ = throwUnary (IndexOutOfBounds $ "Data.Primitive.Array." ++ errMsg ++ "\n" ++ prettyCallStack callStack)
+
+throwUnary :: Exception e => e -> (# a #)
+throwUnary e = raise# (toException e)
 
 newArray :: (HasCallStack, PrimMonad m) => Int -> a -> m (MutableArray (PrimState m) a)
-newArray n x = check "newArray: negative size" (n>=0) (A.newArray n x)
+newArray n x = check "newArray: negative size" (n >= 0) (A.newArray n x)
 
 readArray :: (HasCallStack, PrimMonad m) => MutableArray (PrimState m) a -> Int -> m a
 readArray marr i = do
   let siz = A.sizeofMutableArray marr
-  check "readArray: index of out bounds" (i>=0 && i<siz) (A.readArray marr i)
+  check "readArray: index out of bounds" (i >= 0 && i < siz) (A.readArray marr i)
 
 writeArray :: (HasCallStack, PrimMonad m) => MutableArray (PrimState m) a -> Int -> a -> m ()
 writeArray marr i x = do
   let siz = A.sizeofMutableArray marr
-  check "writeArray: index of out bounds" (i>=0 && i<siz) (A.writeArray marr i x)
+  check "writeArray: index out of bounds" (i >= 0 && i < siz) (A.writeArray marr i x)
 
 indexArray :: HasCallStack => Array a -> Int -> a
-indexArray arr i = check "indexArray: index of out bounds"
-  (i>=0 && i<A.sizeofArray arr)
+indexArray arr i = check "indexArray: index out of bounds"
+  (i >= 0 && i < A.sizeofArray arr)
   (A.indexArray arr i)
 
-indexArrayM :: HasCallStack => Monad m => Array a -> Int -> m a
-indexArrayM arr i = check "indexArrayM: index of out bounds"
-    (i>=0 && i<A.sizeofArray arr)
-    (A.indexArrayM arr i)
+indexArrayM :: (HasCallStack, Monad m) => Array a -> Int -> m a
+indexArrayM arr i = check "indexArrayM: index out of bounds"
+  (i >= 0 && i < A.sizeofArray arr)
+  (A.indexArrayM arr i)
+
+indexArray## :: HasCallStack => Array a -> Int -> (# a #)
+indexArray## arr i = checkUnary "indexArray##: index out of bounds"
+  (i >= 0 && i < A.sizeofArray arr)
+  (A.indexArray## arr i)
 
 {-# NOINLINE errorUnsafeFreeze #-}
 errorUnsafeFreeze :: a
 errorUnsafeFreeze =
-  error "Data.Primitive.Array.Checked.unsafeFreeze:\nAttempted to read from an array after unsafely freezing it."
+  error "Data.Primitive.Array.unsafeFreeze:\nAttempted to read from an array after unsafely freezing it."
 
 unsafeFreezeArray :: (HasCallStack, PrimMonad m)
   => MutableArray (PrimState m) a
@@ -79,11 +101,9 @@ freezeArray
   -> Int                          -- ^ offset
   -> Int                          -- ^ length
   -> m (Array a)
-freezeArray marr s l = do
-  let siz = A.sizeofMutableArray marr
-  check "freezeArray: index range of out bounds"
-    (s>=0 && l>=0 && (s+l)<=siz)
-    (A.freezeArray marr s l)
+freezeArray marr s l = check "freezeArray: index range of out bounds"
+  (s >= 0 && l >= 0 && s + l <= A.sizeofMutableArray marr)
+  (A.freezeArray marr s l)
 
 thawArray
   :: (HasCallStack, PrimMonad m)
@@ -91,9 +111,9 @@ thawArray
   -> Int     -- ^ offset
   -> Int     -- ^ length
   -> m (MutableArray (PrimState m) a)
-thawArray arr s l = check "thawArr: index range of out bounds"
-    (s>=0 && l>=0 && (s+l)<=A.sizeofArray arr)
-    (A.thawArray arr s l)
+thawArray arr s l = check "thawArray: index range of out bounds"
+  (s >= 0 && l >= 0 && s + l <= A.sizeofArray arr)
+  (A.thawArray arr s l)
 
 copyArray :: (HasCallStack, PrimMonad m)
           => MutableArray (PrimState m) a    -- ^ destination array
@@ -105,9 +125,8 @@ copyArray :: (HasCallStack, PrimMonad m)
 copyArray marr s1 arr s2 l = do
   let siz = A.sizeofMutableArray marr
   check "copyArray: index range of out bounds"
-    (s1>=0 && s2>=0 && l>=0 && (s2+l)<=A.sizeofArray arr && (s1+l)<=siz)
+    (s1 >= 0 && s2 >= 0 && l >= 0 && s2 + l <= A.sizeofArray arr && s1 + l <= siz)
     (A.copyArray marr s1 arr s2 l)
-
 
 copyMutableArray :: (HasCallStack, PrimMonad m)
           => MutableArray (PrimState m) a    -- ^ destination array
@@ -122,20 +141,19 @@ copyMutableArray marr1 s1 marr2 s2 l = do
   let explain = L.concat
         [ "[dst size: "
         , show siz1
-        , ", dst off: " 
+        , ", dst off: "
         , show s1
         , ", src size: "
         , show siz2
-        , ", src off: " 
+        , ", src off: "
         , show s2
         , ", copy size: "
         , show l
         , "]"
         ]
   check ("copyMutableArray: index range of out bounds " ++ explain)
-    (s1>=0 && s2>=0 && l>=0 && (s2+l)<=siz2 && (s1+l)<=siz1)
+    (s1 >= 0 && s2 >= 0 && l >= 0 && s2 + l <= siz2 && s1 + l <= siz1)
     (A.copyMutableArray marr1 s1 marr2 s2 l)
-
 
 cloneArray :: HasCallStack
            => Array a -- ^ source array
@@ -143,16 +161,14 @@ cloneArray :: HasCallStack
            -> Int     -- ^ number of elements to copy
            -> Array a
 cloneArray arr s l = check "cloneArray: index range of out bounds"
-    (s>=0 && l>=0 && (s+l)<=A.sizeofArray arr)
-    (A.cloneArray arr s l)
+  (s >= 0 && l >= 0 && s + l <= A.sizeofArray arr)
+  (A.cloneArray arr s l)
 
 cloneMutableArray :: (HasCallStack, PrimMonad m)
         => MutableArray (PrimState m) a -- ^ source array
         -> Int                          -- ^ offset into destination array
         -> Int                          -- ^ number of elements to copy
         -> m (MutableArray (PrimState m) a)
-cloneMutableArray marr s l = do
-  let siz = A.sizeofMutableArray marr
-  check "cloneMutableArray: index range of out bounds"
-    (s>=0 && l>=0 && (s+l)<=siz)
-    (A.cloneMutableArray marr s l)
+cloneMutableArray marr s l = check "cloneMutableArray: index range of out bounds"
+  (s >= 0 && l >= 0 && s + l <= A.sizeofMutableArray marr)
+  (A.cloneMutableArray marr s l)

--- a/src/Data/Primitive/ByteArray.hs
+++ b/src/Data/Primitive/ByteArray.hs
@@ -14,36 +14,49 @@ module Data.Primitive.ByteArray
   , newPinnedByteArray
   , newAlignedPinnedByteArray
   , resizeMutableByteArray
+  , shrinkMutableByteArray
     -- * Element access
   , readByteArray
   , writeByteArray
   , indexByteArray
+    -- * Constructing
+  , A.byteArrayFromList
+  , A.byteArrayFromListN
     -- * Folding
   , A.foldrByteArray
+    -- * Comparing
+  , compareByteArrays
     -- * Freezing and thawing
+  , freezeByteArray
+  , thawByteArray
   , A.unsafeFreezeByteArray
   , A.unsafeThawByteArray
     -- * Block operations
   , copyByteArray
   , copyMutableByteArray
+  , copyByteArrayToPtr
+  , copyMutableByteArrayToPtr
+  , copyByteArrayToAddr
+  , copyMutableByteArrayToAddr
   , moveByteArray
   , setByteArray
   , fillByteArray
-  , A.copyMutableByteArrayToAddr
+  , cloneByteArray
+  , cloneMutableByteArray
   -- * Information
   , A.sizeofByteArray
   , A.sizeofMutableByteArray
   , A.getSizeofMutableByteArray
   , A.sameMutableByteArray
-  , A.byteArrayContents
-  , A.mutableByteArrayContents
   , A.isByteArrayPinned
   , A.isMutableByteArrayPinned
+  , A.byteArrayContents
+  , A.mutableByteArrayContents
   ) where
 
 import Control.Monad.Primitive (PrimMonad,PrimState)
 import Control.Exception (throw, ArrayException(..))
-import Data.Primitive.Types (Prim,sizeOf)
+import Data.Primitive.Types (Prim, Ptr, sizeOf)
 import Data.Proxy (Proxy(..))
 import Data.Word (Word8)
 import "primitive" Data.Primitive.ByteArray (ByteArray,MutableByteArray)
@@ -66,23 +79,31 @@ getElementSizeofMutableByteArray _ arr = do
 
 newByteArray :: (HasCallStack, PrimMonad m) => Int -> m (MutableByteArray (PrimState m))
 newByteArray n =
-    check "newByteArray: negative size" (n>=0)
-  $ check ("newByteArray: reqeusted " ++ show n ++ " bytes") (n<1024*1024*1024)
-  $ (A.newByteArray n)
+    check "newByteArray: negative size" (n >= 0)
+  $ check ("newByteArray: requested " ++ show n ++ " bytes") (n < 1024*1024*1024)
+  $ A.newByteArray n
 
 newPinnedByteArray :: (HasCallStack, PrimMonad m) => Int -> m (MutableByteArray (PrimState m))
-newPinnedByteArray n = check "newPinnedByteArray: negative size" (n>=0) (A.newPinnedByteArray n)
+newPinnedByteArray n = check "newPinnedByteArray: negative size" (n >= 0) (A.newPinnedByteArray n)
 
 newAlignedPinnedByteArray :: (HasCallStack, PrimMonad m) => Int -> Int -> m (MutableByteArray (PrimState m))
-newAlignedPinnedByteArray n k = check "newAlignedPinnedByteArray: negative size" (n>=0) (A.newAlignedPinnedByteArray n k)
+newAlignedPinnedByteArray n k = check "newAlignedPinnedByteArray: negative size" (n >= 0) (A.newAlignedPinnedByteArray n k)
 
 resizeMutableByteArray :: PrimMonad m => MutableByteArray (PrimState m) -> Int -> m (MutableByteArray (PrimState m))
-resizeMutableByteArray a n = check "resizeMutableByteArray: negative size" (n>=0) (A.resizeMutableByteArray a n)
+resizeMutableByteArray a n = check "resizeMutableByteArray: negative size" (n >= 0) (A.resizeMutableByteArray a n)
+
+shrinkMutableByteArray :: (HasCallStack, PrimMonad m)
+  => MutableByteArray (PrimState m)
+  -> Int -- ^ new size
+  -> m ()
+shrinkMutableByteArray marr n = do
+  old <- A.getSizeofMutableByteArray marr
+  check "shrinkMutableByteArray: illegal new size" (n >= 0 && n <= old) (A.shrinkMutableByteArray marr n)
 
 readByteArray :: forall m a. (HasCallStack, Prim a, PrimMonad m) => MutableByteArray (PrimState m) -> Int -> m a
 readByteArray marr i = do
   siz <- getElementSizeofMutableByteArray (Proxy :: Proxy a) marr
-  check "readByteArray: index of out bounds" (i>=0 && i<siz) (A.readByteArray marr i)
+  check "readByteArray: index out of bounds" (i >= 0 && i < siz) (A.readByteArray marr i)
 
 writeByteArray :: forall m a. (HasCallStack, Prim a, PrimMonad m) => MutableByteArray (PrimState m) -> Int -> a -> m ()
 writeByteArray marr i x = do
@@ -96,17 +117,42 @@ writeByteArray marr i x = do
         , show (sizeOf (undefined :: a))
         , "]"
         ]
-  check ("writeByteArray: index of out bounds " ++ explain)
-    (i>=0 && i<siz)
+  check ("writeByteArray: index out of bounds " ++ explain)
+    (i >= 0 && i < siz)
     (A.writeByteArray marr i x)
 
 -- This one is a little special. We allow users to index past the
 -- end of the byte array as long as the content grabbed is within
 -- the last machine word of the byte array.
 indexByteArray :: forall a. (HasCallStack, Prim a) => ByteArray -> Int -> a
-indexByteArray arr i = check "indexByteArray: index of out bounds"
-  (i>=0 && i< elementSizeofByteArray (Proxy :: Proxy a) arr)
+indexByteArray arr i = check "indexByteArray: index out of bounds"
+  (i >= 0 && i < elementSizeofByteArray (Proxy :: Proxy a) arr)
   (A.indexByteArray arr i)
+
+compareByteArrays :: ByteArray -> Int -> ByteArray -> Int -> Int -> Ordering
+compareByteArrays arr1 off1 arr2 off2 len = check "compareByteArrays: index range out of bounds"
+  (off1 >= 0 && off2 >= 0 && off1 + len <= A.sizeofByteArray arr1 && off2 + len <= A.sizeofByteArray arr2)
+  (A.compareByteArrays arr1 off1 arr2 off2 len)
+
+freezeByteArray
+  :: (HasCallStack, PrimMonad m)
+  => MutableByteArray (PrimState m) -- ^ source
+  -> Int                          -- ^ offset
+  -> Int                          -- ^ length
+  -> m ByteArray
+freezeByteArray marr s l = check "freezeByteArray: index range of out bounds"
+  (s >= 0 && l >= 0 && s + l <= A.sizeofMutableByteArray marr)
+  (A.freezeByteArray marr s l)
+
+thawByteArray
+  :: (HasCallStack, PrimMonad m)
+  => ByteArray -- ^ source
+  -> Int     -- ^ offset
+  -> Int     -- ^ length
+  -> m (MutableByteArray (PrimState m))
+thawByteArray arr s l = check "thawByteArray: index range of out bounds"
+  (s >= 0 && l >= 0 && s + l <= A.sizeofByteArray arr)
+  (A.thawByteArray arr s l)
 
 copyByteArray :: forall m. (HasCallStack, PrimMonad m)
   => MutableByteArray (PrimState m) -- ^ destination array
@@ -118,9 +164,8 @@ copyByteArray :: forall m. (HasCallStack, PrimMonad m)
 copyByteArray marr s1 arr s2 l = do
   let siz = A.sizeofMutableByteArray marr
   check "copyByteArray: index range of out bounds"
-    (s1>=0 && s2>=0 && l>=0 && (s2+l)<= A.sizeofByteArray arr && (s1+l)<=siz)
+    (s1 >= 0 && s2 >= 0 && l >= 0 && s2 + l <= A.sizeofByteArray arr && s1 + l <= siz)
     (A.copyByteArray marr s1 arr s2 l)
-
 
 copyMutableByteArray :: forall m. (HasCallStack, PrimMonad m)
   => MutableByteArray (PrimState m) -- ^ destination array
@@ -133,21 +178,105 @@ copyMutableByteArray marr1 s1 marr2 s2 l = do
   let siz1 = A.sizeofMutableByteArray marr1
   let siz2 = A.sizeofMutableByteArray marr2
   check "copyMutableByteArray: index range of out bounds"
-    (s1>=0 && s2>=0 && l>=0 && (s2+l)<=siz2 && (s1+l)<=siz1)
+    (s1 >= 0 && s2 >= 0 && l >= 0 && s2 + l <= siz2 && s1 + l <= siz1)
     (A.copyMutableByteArray marr1 s1 marr2 s2 l)
+
+copyByteArrayToPtr :: forall m a. (HasCallStack, PrimMonad m, Prim a)
+  => Ptr a -- ^ destination pointer
+  -> ByteArray -- ^ source array
+  -> Int -- ^ offset into source array
+  -> Int -- ^ number of elements to copy
+  -> m ()
+copyByteArrayToPtr ptr arr s l = do
+  let srcSz = elementSizeofByteArray (Proxy :: Proxy a) arr
+  let explain = L.concat
+        [ "[src_sz: "
+        , show srcSz
+        , ", src_off: "
+        , show s
+        , ", len: "
+        , show l
+        , "]"
+        ]
+  check ("copyByteArrayToPtr: index range of out bounds " ++ explain)
+    (s >= 0 && l >= 0 && s + l <= srcSz)
+    (A.copyByteArrayToPtr ptr arr s l)
+
+copyMutableByteArrayToPtr :: forall m a. (HasCallStack, PrimMonad m, Prim a)
+  => Ptr a -- ^ destination pointer
+  -> MutableByteArray (PrimState m) -- ^ source array
+  -> Int -- ^ offset into source array
+  -> Int -- ^ number of elements to copy
+  -> m ()
+copyMutableByteArrayToPtr ptr marr s l = do
+  srcSz <- getElementSizeofMutableByteArray (Proxy :: Proxy a) marr
+  let explain = L.concat
+        [ "[src_sz: "
+        , show srcSz
+        , ", src_off: "
+        , show s
+        , ", len: "
+        , show l
+        , "]"
+        ]
+  check ("copyMutableByteArrayToPtr: index range of out bounds " ++ explain)
+    (s >= 0 && l >= 0 && s + l <= srcSz)
+    (A.copyMutableByteArrayToPtr ptr marr s l)
+
+copyByteArrayToAddr :: (HasCallStack, PrimMonad m)
+  => Ptr Word8 -- ^ destination pointer
+  -> ByteArray -- ^ source array
+  -> Int -- ^ offset into source array
+  -> Int -- ^ number of bytes to copy
+  -> m ()
+copyByteArrayToAddr ptr arr s l = do
+  let srcSz = A.sizeofByteArray arr
+  let explain = L.concat
+        [ "[src_sz: "
+        , show srcSz
+        , ", src_off: "
+        , show s
+        , ", len: "
+        , show l
+        , "]"
+        ]
+  check ("copyByteArrayToAddr: index range of out bounds " ++ explain)
+    (s >= 0 && l >= 0 && s + l <= srcSz)
+    (A.copyByteArrayToAddr ptr arr s l)
+
+copyMutableByteArrayToAddr :: (HasCallStack, PrimMonad m)
+  => Ptr Word8 -- ^ destination pointer
+  -> MutableByteArray (PrimState m) -- ^ source array
+  -> Int -- ^ offset into source array
+  -> Int -- ^ number of bytes to copy
+  -> m ()
+copyMutableByteArrayToAddr ptr marr s l = do
+  srcSz <- A.getSizeofMutableByteArray marr
+  let explain = L.concat
+        [ "[src_sz: "
+        , show srcSz
+        , ", src_off: "
+        , show s
+        , ", len: "
+        , show l
+        , "]"
+        ]
+  check ("copyMutableByteArrayToAddr: index range of out bounds " ++ explain)
+    (s >= 0 && l >= 0 && s + l <= srcSz)
+    (A.copyMutableByteArrayToAddr ptr marr s l)
 
 moveByteArray :: forall m. (HasCallStack, PrimMonad m)
   => MutableByteArray (PrimState m) -- ^ destination array
   -> Int -- ^ offset into destination array
   -> MutableByteArray (PrimState m) -- ^ source array
   -> Int -- ^ offset into source array
-  -> Int -- ^ number of elements to copy
+  -> Int -- ^ number of bytes to copy
   -> m ()
 moveByteArray marr1 s1 marr2 s2 l = do
   let siz1 = A.sizeofMutableByteArray marr1
   let siz2 = A.sizeofMutableByteArray marr2
   check "moveByteArray: index range of out bounds"
-    (s1>=0 && s2>=0 && l>=0 && (s2+l)<=siz2 && (s1+l)<=siz1)
+    (s1 >= 0 && s2 >= 0 && l >= 0 && s2 + l <= siz2 && s1 + l <= siz1)
     (A.moveByteArray marr1 s1 marr2 s2 l)
 
 fillByteArray :: (HasCallStack, PrimMonad m)
@@ -167,6 +296,23 @@ setByteArray :: forall m a. (HasCallStack, Prim a, PrimMonad m)
 setByteArray dst doff sz x = do
   siz <- getElementSizeofMutableByteArray (Proxy :: Proxy a) dst
   check "setByteArray: index range of out bounds"
-    (doff>=0 && (doff+sz)<=siz)
+    (doff >= 0 && doff + sz <= siz)
     (A.setByteArray dst doff sz x)
 
+cloneByteArray :: HasCallStack
+  => ByteArray -- ^ source array
+  -> Int     -- ^ offset into destination array
+  -> Int     -- ^ number of bytes to copy
+  -> ByteArray
+cloneByteArray arr s l = check "cloneByteArray: index range of out bounds"
+  (s >= 0 && l >= 0 && s + l <= A.sizeofByteArray arr)
+  (A.cloneByteArray arr s l)
+
+cloneMutableByteArray :: (HasCallStack, PrimMonad m)
+  => MutableByteArray (PrimState m) -- ^ source array
+  -> Int                          -- ^ offset into destination array
+  -> Int                          -- ^ number of bytes to copy
+  -> m (MutableByteArray (PrimState m))
+cloneMutableByteArray marr s l = check "cloneMutableByteArray: index range of out bounds"
+  (s >= 0 && l >= 0 && s + l <= A.sizeofMutableByteArray marr)
+  (A.cloneMutableByteArray marr s l)


### PR DESCRIPTION
Fixes https://github.com/haskell-primitive/primitive-checked/issues/2.

Changes:
* Delete unnecessary files
* Add new `primitive` functions
* Add missing check for `copyPrimArrayToPtr` and `copyMutablePrimArrayToPtr`
* Clean up the code