### PR TITLE
compatibility with recent primitive

### DIFF
--- a/primitive-checked.cabal
+++ b/primitive-checked.cabal
@@ -42,7 +42,7 @@ library
       src
   build-depends:
       base >= 4.9.1.0 && < 5
-    , primitive == 0.7.3.*
+    , primitive >= 0.7.3
   exposed-modules:
     Data.Primitive
     Data.Primitive.Array

--- a/src/Data/Primitive/Array.hs
+++ b/src/Data/Primitive/Array.hs
@@ -27,8 +27,8 @@ module Data.Primitive.Array
   , A.sizeofArray
   , A.sizeofMutableArray
   , A.emptyArray
-  , A.fromListN
-  , A.fromList
+  , G.fromListN
+  , G.fromList
   , A.arrayFromListN
   , A.arrayFromList
   , A.mapArray'
@@ -42,6 +42,7 @@ import qualified Data.List as L
 import "primitive" Data.Primitive.Array (Array, MutableArray)
 import qualified "primitive" Data.Primitive.Array as A
 import GHC.Exts (raise#)
+import GHC.IsList as G (fromListN, fromList)
 import GHC.Stack
 
 check :: HasCallStack => String -> Bool -> a -> a


### PR DESCRIPTION
Since primitive-9.0, isList an isListN are no longer reexported by Data.Primitive.Array.